### PR TITLE
Fixed the raised ArgumentError error when using the refute_raises method with an error message as the second argument.

### DIFF
--- a/lib/test_bench/fixture/fixture.rb
+++ b/lib/test_bench/fixture/fixture.rb
@@ -114,7 +114,7 @@ module TestBench
       assert(result, caller_location: caller_location)
     end
 
-    def refute_raises(error_class=nil, strict: nil, caller_location: nil, &block)
+    def refute_raises(error_class=nil, message=nil, strict: nil, caller_location: nil, &block)
       if error_class.nil?
         strict ||= false
         error_class = StandardError
@@ -140,7 +140,11 @@ module TestBench
         raise error
       end
 
-      result = false
+      if message.nil?
+        result = false
+      else
+        result = error.message != message
+      end
 
     ensure
       unless result.nil?


### PR DESCRIPTION
This error was raised when trying the examples of refute_raises with the error message as the second argument:

```
# Passes
refute_raises(RuntimeError, 'Some error message') do
  raise 'Some other error message'
end

# Fails
refute_raises(RuntimeError, 'Some error message') do
  raise 'Some error message'
end
```